### PR TITLE
(AWS) Fix issues with suspended accounts + handle assumption errors better

### DIFF
--- a/AWS/aws_cspm_benchmark.py
+++ b/AWS/aws_cspm_benchmark.py
@@ -14,20 +14,20 @@ from tabulate import tabulate
 
 data = []
 headers = {
-            'account_id': 'AWS Account ID',
-            "region": "Region",
-            "vms_terminated": "Terminated VMs",
-            "vms_running": "Running VMs",
-            'kubenodes_terminated': "Terminated Kubernetes Nodes",
-            'kubenodes_running': "Running Kubernetes Nodes"
+    'account_id': 'AWS Account ID',
+    "region": "Region",
+    "vms_terminated": "Terminated VMs",
+    "vms_running": "Running VMs",
+    'kubenodes_terminated': "Terminated Kubernetes Nodes",
+    'kubenodes_running': "Running Kubernetes Nodes"
 }
 totals = {
-            "region": "TOTAL",
-            'account_id': 'TOTAL',
-            "vms_terminated": 0,
-            "vms_running": 0,
-            'kubenodes_terminated': 0,
-            'kubenodes_running': 0
+    "region": "TOTAL",
+    'account_id': 'TOTAL',
+    "vms_terminated": 0,
+    "vms_running": 0,
+    'kubenodes_terminated': 0,
+    'kubenodes_running': 0
 }
 
 
@@ -80,7 +80,7 @@ class AWSOrgAccess:
                 aws_secret_access_key=credentials['Credentials']['SecretAccessKey'],
                 aws_session_token=credentials['Credentials']['SessionToken'],
                 region_name='us-east-1'
-               )
+            )
         except self.master_sts.exceptions.ClientError as exc:
             # Print the error and continue.
             # TODO: Handle what to do with accounts that cannot be accessed

--- a/AWS/aws_cspm_benchmark.py
+++ b/AWS/aws_cspm_benchmark.py
@@ -61,13 +61,13 @@ class AWSOrgAccess:
     def aws_handle(self, account):
         if account['Id'] == self.master_account_id:
             return AWSHandle(aws_session=self.master_session, account_id=self.master_account_id)
-        else:
-            # Check if new_session returns a session object
-            session = self.new_session(account['Id'])
-            if session:
-                return AWSHandle(aws_session=session, account_id=account['Id'])
-            else:
-                return None
+
+        # Check if new_session returns a session object
+        session = self.new_session(account['Id'])
+        if session:
+            return AWSHandle(aws_session=session, account_id=account['Id'])
+
+        return None
 
     def new_session(self, account_id):
         try:
@@ -83,9 +83,10 @@ class AWSOrgAccess:
             )
         except self.master_sts.exceptions.ClientError as exc:
             # Print the error and continue.
-            # TODO: Handle what to do with accounts that cannot be accessed
+            # Handle what to do with accounts that cannot be accessed
             # due to assuming role errors.
             print("Cannot access adjacent account: ", account_id, exc)
+            return None
 
 
 class AWSHandle:


### PR DESCRIPTION
Fixes #25 

This PR introduces the ability to skip non-ACTIVE status accounts in AWS. In addition, it now handles accounts where you may not be able to AssumeRole on - by printing out the acct# and issue, and continuing processing. This way you have an idea of what accounts aren't working based on output. It also allows you to continue processing on the accounts you do have access for. 

Future PR: Consider handling non-active and assumption errors in a way that may make sense to show them in the table with the appropriate status. 