### PR TITLE
Add AWS_ASSUME_ROLE_NAME environment variable support to benchmark.sh

### DIFF
--- a/AWS/aws_cspm_benchmark.py
+++ b/AWS/aws_cspm_benchmark.py
@@ -28,9 +28,14 @@ totals = {
     'kubenodes_running': 0
 }
 
+
 def parse_args():
-    parser = argparse.ArgumentParser(description="Analyze AWS accounts and regions for EC2 instances and Kubernetes nodes.")
-    parser.add_argument("-r", "--role_name", default="OrganizationAccountAccessRole", help="Specify a custom role name to assume into.")
+    parser = argparse.ArgumentParser(
+        description="Analyze AWS accounts and regions for EC2 instances and Kubernetes nodes.")
+    parser.add_argument(
+        "-r", "--role_name",
+        default="OrganizationAccountAccessRole",
+        help="Specify a custom role name to assume into.")
     return parser.parse_args()
 
 

--- a/AWS/aws_cspm_benchmark.py
+++ b/AWS/aws_cspm_benchmark.py
@@ -4,6 +4,7 @@ aws-cspm-benchmark.py
 Assists with provisioning calculations by retrieving a count of
 all billable resources attached to an AWS account.
 """
+import argparse
 import csv
 import boto3
 from tabulate import tabulate
@@ -26,6 +27,11 @@ totals = {
     'kubenodes_terminated': 0,
     'kubenodes_running': 0
 }
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Analyze AWS accounts and regions for EC2 instances and Kubernetes nodes.")
+    parser.add_argument("-r", "--role_name", default="OrganizationAccountAccessRole", help="Specify a custom role name to assume into.")
+    return parser.parse_args()
 
 
 class AWSOrgAccess:
@@ -69,7 +75,7 @@ class AWSOrgAccess:
     def new_session(self, account_id):
         try:
             credentials = self.master_sts.assume_role(
-                RoleArn=f'arn:aws:iam::{account_id}:role/OrganizationAccountAccessRole',
+                RoleArn=f'arn:aws:iam::{account_id}:role/{args.role_name}',
                 RoleSessionName=account_id
             )
             return boto3.session.Session(
@@ -131,6 +137,8 @@ class AWSHandle:
 
         return self.acc_id
 
+
+args = parse_args()
 
 for aws in AWSOrgAccess().accounts():
     for region in aws.regions:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ These utilities have been developed to assist you in calculating the overall siz
 
 The `benchmark.sh` entrypoint script helps you to perform sizing calculations for your cloud resources. It detects the cloud provider (AWS, Azure, or GCP) and downloads the necessary scripts to perform the calculation. You can also pass one or more cloud providers as arguments.
 
+***Configuration:***
+
+The script recognizes the following environmental variables:
+
+- `AWS_ASSUME_ROLE_NAME`: The name of the AWS role to assume (optional)
+
+To use, please export the variable in your environment prior to running the script:
+
+```shell
+export ENV_VARIABLE="Example-Value"
+```
+
 ***Usage:***
 
 ```shell

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -60,9 +60,9 @@ call_benchmark_script() {
 
     case "$cloud" in
     AWS)
-        if [[ ! -z $AWS_ASSUME_ROLE_NAME ]]; then
-            args="-r $AWS_ASSUME_ROLE_NAME"
-        fi
+        [[ ! -z $AWS_ASSUME_ROLE_NAME ]] && args="-r $AWS_ASSUME_ROLE_NAME"
+        # Below is how we would pass in additional arguments if needed
+        #[[ ! -z $AWS_EXAMPLE ]] && args+=" -t $AWS_EXAMPLE"
         ;;
     Azure)
         args=""
@@ -77,7 +77,7 @@ call_benchmark_script() {
         ;;
     esac
 
-    python3 "${file}" "${args}"
+    python3 "${file}" ${args}
 }
 
 audit() {

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -61,13 +61,13 @@ is_valid_cloud() {
 call_benchmark_script() {
     local cloud="$1"
     local file="$2"
-    local args=""
+    local args=()
 
     case "$cloud" in
     AWS)
-        [[ -n $AWS_ASSUME_ROLE_NAME ]] && args="-r $AWS_ASSUME_ROLE_NAME"
+        [[ -n $AWS_ASSUME_ROLE_NAME ]] && args+=("-r" "$AWS_ASSUME_ROLE_NAME")
         # Below is how we would pass in additional arguments if needed
-        #[[ -n $AWS_EXAMPLE ]] && args+=" -t $AWS_EXAMPLE"
+        # [[ -n $AWS_EXAMPLE ]] && args+=("-t" "$AWS_EXAMPLE")
         ;;
     Azure)
         ;;
@@ -80,8 +80,7 @@ call_benchmark_script() {
         ;;
     esac
 
-    # python3 "${file}" ${args}
-    echo "python3 ${file} ${args}"
+    python3 "${file}" "${args[@]}"
 }
 
 audit() {

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -3,7 +3,7 @@
 # Based on the cloud provider, downloads the necessary scripts
 # to perform a sizing calculation.
 
-base_url=https://raw.githubusercontent.com/CrowdStrike/Cloud-Benchmark/main
+base_url=https://raw.githubusercontent.com/carlosmmatos/Cloud-Benchmark/carlosmmatos/issue26
 
 # Usage message
 usage() {
@@ -51,6 +51,35 @@ is_valid_cloud() {
     esac
 }
 
+# Calls the python script for the specified cloud provider with the
+# appropriate arguments
+call_benchmark_script() {
+    local cloud="$1"
+    local file="$2"
+    local args
+
+    case "$cloud" in
+    AWS)
+        if [[ ! -z $AWS_ASSUME_ROLE_NAME ]]; then
+            args="-r $AWS_ASSUME_ROLE_NAME"
+        fi
+        ;;
+    Azure)
+        args=""
+        ;;
+    GCP)
+        args=""
+        ;;
+    *)
+        echo "Invalid cloud provider specified: $cloud"
+        usage
+        exit 1
+        ;;
+    esac
+
+    python3 "${file}" "${args}"
+}
+
 audit() {
     CLOUD="$1"
     echo "Working in cloud: ${CLOUD}"
@@ -62,7 +91,8 @@ audit() {
     python3 -m pip install --disable-pip-version-check -qq -r requirements.txt
     file="${cloud}_cspm_benchmark.py"
     curl -s -o "${file}" "${base_url}/${CLOUD}/${file}"
-    python3 "${file}"
+
+    call_benchmark_script "$CLOUD" "${file}"
 }
 
 check_python3

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -3,7 +3,7 @@
 # Based on the cloud provider, downloads the necessary scripts
 # to perform a sizing calculation.
 
-base_url=https://raw.githubusercontent.com/carlosmmatos/Cloud-Benchmark/carlosmmatos/issue26
+base_url=https://raw.githubusercontent.com/CrowdStrike/Cloud-Benchmark/main
 
 # Usage message
 usage() {
@@ -11,7 +11,12 @@ usage() {
     Usage: $0 [aws|azure|gcp]...
 
     More than one cloud provider can be specified.
-    If no cloud provider is specified, the script will attempt to detect the provider."""
+    If no cloud provider is specified, the script will attempt to detect the provider.
+    ----------------------------------------------------------------------------------
+
+    The script recognizes the following environment variables:
+
+        - AWS_ASSUME_ROLE_NAME: The name of the AWS role to assume (optional)"""
 }
 
 # Check if the system has Python3 and pip installed
@@ -56,19 +61,17 @@ is_valid_cloud() {
 call_benchmark_script() {
     local cloud="$1"
     local file="$2"
-    local args
+    local args=""
 
     case "$cloud" in
     AWS)
-        [[ ! -z $AWS_ASSUME_ROLE_NAME ]] && args="-r $AWS_ASSUME_ROLE_NAME"
+        [[ -n $AWS_ASSUME_ROLE_NAME ]] && args="-r $AWS_ASSUME_ROLE_NAME"
         # Below is how we would pass in additional arguments if needed
-        #[[ ! -z $AWS_EXAMPLE ]] && args+=" -t $AWS_EXAMPLE"
+        #[[ -n $AWS_EXAMPLE ]] && args+=" -t $AWS_EXAMPLE"
         ;;
     Azure)
-        args=""
         ;;
     GCP)
-        args=""
         ;;
     *)
         echo "Invalid cloud provider specified: $cloud"
@@ -77,7 +80,8 @@ call_benchmark_script() {
         ;;
     esac
 
-    python3 "${file}" ${args}
+    # python3 "${file}" ${args}
+    echo "python3 ${file} ${args}"
 }
 
 audit() {


### PR DESCRIPTION
fixes #26 

This pull request updates the benchmark.sh script to support the AWS_ASSUME_ROLE_NAME environment variable, allowing users to assume a specific AWS role when running the benchmark calculations.

## Changes:

- Updated the usage() function to include information about the AWS_ASSUME_ROLE_NAME environment variable.
- Added a new function call_benchmark_script() that handles the passing of the environment variable and any additional arguments to the corresponding Python script for the specified cloud provider.
- Modified the audit() function to use the new call_benchmark_script() function.
- Added arg support to aws_cspm_benchmark python script

## Usage example:

```shell
export AWS_ASSUME_ROLE_NAME=my_role_name
curl https://raw.githubusercontent.com/CrowdStrike/falcon-benchmark/main/benchmark.sh | bash -s -- aws
```

With these changes, users can now pass the AWS_ASSUME_ROLE_NAME environment variable to the script, allowing them to assume the specified AWS role for benchmark calculations.