### PR TITLE
docs: clarify GCP sys-* project filtering and improve documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,34 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
+#  you could uncomment the following to ignore the enitre vscode folder
+.vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# AI Assistants
+#  Various AI coding assistants create local cache, settings, and conversation history
+#  These contain user-specific data and should not be committed to version control
+.cursorignore
+.cursorindexingignore
+.claude/
+CLAUDE.md
+.anthropic/
+.openai/
+.codeium/
+.tabnine/
+.github-copilot/
+.roo/
+.aider/
+.aider*
+.clinerules/
+memory-bank/

--- a/GCP/README.md
+++ b/GCP/README.md
@@ -18,15 +18,17 @@ No changes will be made to your account. No data will be sent anywhere and will 
 
 ## Project Filtering
 
-The GCP script automatically excludes Google system projects (`sys-*`) by default for better performance. These system projects typically don't contain billable resources relevant for CSPM benchmarking.
+The GCP script automatically excludes projects with `sys-*` prefixes by default. This improves performance because Google Apps Script commonly creates projects with this naming pattern that don't contain billable compute resources relevant for CSPM benchmarking.
+
+If you don't use Google Apps Script, or have legitimate projects that start with `sys-*` that should be included in the scan, you can enable scanning of these projects.
 
 ### Filtering Environment Variables
 
-**System Projects:**
+**sys-* Projects:**
 
 ```bash
-# Include Google system projects (default: false)
-export GCP_INCLUDE_SYSTEM_PROJECTS=true
+# Include projects starting with sys-* (default: false)
+export GCP_ENABLE_SYS_PROJECTS=true
 ./benchmark.sh gcp
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 ![CrowdStrike Logo (Light)](https://raw.githubusercontent.com/CrowdStrike/.github/main/assets/cs-logo-light-mode.png#gh-light-mode-only)
 ![CrowdStrike Logo (Dark)](https://raw.githubusercontent.com/CrowdStrike/.github/main/assets/cs-logo-dark-mode.png#gh-dark-mode-only)
 
-# CrowdStrike CWP / Horizon Benchmark Utilities
+# CrowdStrike Cloud Resource Estimator
 
-These utilities have been developed to assist you in calculating the overall size of a cloud deployment.
+This multi-cloud resource auditing utility helps organizations calculate the size of their cloud deployments across AWS, Azure, and Google Cloud Platform. It's designed for **CrowdStrike CWP/Horizon licensing calculations** and cloud security posture management (CSPM) benchmarking.
+
+## What This Tool Does
+
+The Cloud Resource Estimator performs **read-only** scanning of your cloud infrastructure to count:
+
+- Virtual machines and compute instances
+- Container services (ECS, AKS, GKE)
+- Serverless functions and managed services
+- Other billable resources relevant for CSPM licensing
+
+**No changes are made to your cloud environment** - this is strictly an auditing and counting tool.
 
 ## Running an audit
 
@@ -11,7 +22,9 @@ The `benchmark.sh` entrypoint script helps you to perform sizing calculations fo
 
 ## Configuration
 
-The script recognizes the following environmental variables for AWS:
+Each cloud provider supports various environment variables for performance tuning and filtering. Below are the key AWS configuration options (for complete configuration details, see the provider-specific README files):
+
+### AWS Configuration
 
 | Variable | Default | Description |
 | :--- | :--- | :--- |
@@ -32,6 +45,13 @@ To use, please export variables in your environment prior to running the script:
 ```shell
 export AWS_ASSUME_ROLE_NAME="Example-Role-Name"
 ```
+
+### Azure and GCP Configuration
+
+Azure and GCP also support performance tuning and filtering options. For complete configuration details:
+
+- **Azure**: See [Azure README](Azure/README.md) for subscription filtering and performance settings
+- **GCP**: See [GCP README](GCP/README.md) for project filtering (including sys-* project handling) and threading options
 
 **Note**: see [AWS Readme](AWS/README.md) for detailed configuration options.
 
@@ -60,7 +80,7 @@ For those who prefer to run the script locally, or would like to run the script 
 - Python 3
 - pip
 - curl
-- Approprate cloud provider CLI ([AWS](https://aws.amazon.com/cli/), [Azure](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli), [GCP](https://cloud.google.com/sdk/docs/install))
+- Appropriate cloud provider CLI ([AWS](https://aws.amazon.com/cli/), [Azure](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli), [GCP](https://cloud.google.com/sdk/docs/install))
 
 #### Steps
 


### PR DESCRIPTION
## Summary
Improves documentation clarity and renames GCP environment variable based on user feedback about confusion between "system projects" terminology and actual Apps Script project filtering. 

> [!IMPORTANT]
> Because GCP allows you to create projects with any prefix - for those **not** using Apps Script or have reasons to include it, use the new `GCP_ENABLE_SYS_PROJECTS` variable.

## Changes
- **Renamed environment variable**: `GCP_INCLUDE_SYSTEM_PROJECTS` → `GCP_ENABLE_SYS_PROJECTS`
- **Updated terminology**: "system projects" → "sys-* projects" for accuracy
- **Added context**: Explains Google Apps Script commonly creates sys-* projects
- **Enhanced main README**: Complete overhaul with clear tool purpose and multi-cloud configuration
- **Fixed typo**: "Approprate" → "Appropriate"