### PR TITLE
chore: release workflow with checksum

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  release:
+    types:
+      - created
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build release artifacts and checksums
+        run: |
+          list_of_files="benchmark.sh AWS/aws_cspm_benchmark.py Azure/azure_cspm_benchmark.py GCP/gcp_cspm_benchmark.py"
+
+          for file in $list_of_files; do
+            pushd $(dirname $file) > /dev/null
+            sha256sum $(basename $file)
+            popd > /dev/null
+          done > checksum.txt
+
+          gh release upload $TAG $list_of_files checksum.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}

--- a/AWS/README.md
+++ b/AWS/README.md
@@ -19,6 +19,56 @@ Reported Resources will include a count of each of the following resource types 
 | Active EKS Fargate Profiles | Active EKS Fargate Profiles for each EKS Cluster. Excludes any existing Falcon Profiles eg. fp-falcon* |
 | ECS Service Fargate Tasks | DesiredCount of tasks in Active ECS Services.  Excludes standalone tasks or tasks that are scheduled outside of Services |
   
+## 🔐 Least-Privilege IAM Policy
+
+This script requires only the following read-only actions. Attach this policy to the IAM role or user you use to run the script — do not use root credentials or `AdministratorAccess`.
+
+**For the management/payer account** (the identity that runs the script):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CloudResourceEstimatorManagement",
+      "Effect": "Allow",
+      "Action": [
+        "sts:GetCallerIdentity",
+        "sts:AssumeRole",
+        "organizations:ListAccounts"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+**For each member account** (attach to the role the script assumes, e.g. `OrganizationAccountAccessRole`):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CloudResourceEstimatorReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "sts:GetCallerIdentity",
+        "ec2:DescribeRegions",
+        "ec2:DescribeInstances",
+        "eks:ListClusters",
+        "eks:ListFargateProfiles",
+        "eks:DescribeFargateProfile",
+        "ecs:ListClusters",
+        "ecs:ListServices",
+        "ecs:DescribeServices"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
 ## ▶️ Usage
 
 ### Initialize execution environment
@@ -42,7 +92,12 @@ export AWS_ASSUME_ROLE_NAME="Example-Role-Name"
 ### Execute Script
 
 ```shell
-curl https://raw.githubusercontent.com/CrowdStrike/cloud-resource-estimator/main/benchmark.sh | bash
+RELEASE_VERSION="v1.0.0"
+curl -sLO "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/benchmark.sh"
+curl -sL "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/checksum.txt" \
+  | grep benchmark.sh | sha256sum -c        # Linux / CloudShell
+  # | grep benchmark.sh | shasum -a 256 -c  # macOS
+chmod +x benchmark.sh && ./benchmark.sh aws
 ```
 
 ### Collect the findings
@@ -74,7 +129,12 @@ cat ./cloud-benchmark/*benchmark*.csv
 #### Standard Processing for Small Organizations (< 50 accounts) 
 ```shell
 # Default settings work well - no configuration needed
-curl https://raw.githubusercontent.com/CrowdStrike/cloud-resource-estimator/main/benchmark.sh | bash
+RELEASE_VERSION="v1.0.0"
+curl -sLO "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/benchmark.sh"
+curl -sL "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/checksum.txt" \
+  | grep benchmark.sh | sha256sum -c        # Linux / CloudShell
+  # | grep benchmark.sh | shasum -a 256 -c  # macOS
+chmod +x benchmark.sh && ./benchmark.sh aws
 ```
 
 #### Fast Processing for Smaller Organizations (< 50 accounts)
@@ -83,7 +143,12 @@ export AWS_THREADS=8
 export AWS_BATCH_SIZE=50
 export AWS_BATCH_DELAY=15
 export AWS_API_DELAY=0.05
-curl https://raw.githubusercontent.com/CrowdStrike/cloud-resource-estimator/main/benchmark.sh | bash
+RELEASE_VERSION="v1.0.0"
+curl -sLO "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/benchmark.sh"
+curl -sL "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/checksum.txt" \
+  | grep benchmark.sh | sha256sum -c        # Linux / CloudShell
+  # | grep benchmark.sh | shasum -a 256 -c  # macOS
+chmod +x benchmark.sh && ./benchmark.sh aws
 ```
 
 #### Medium Organizations (50-200 accounts)
@@ -91,7 +156,12 @@ curl https://raw.githubusercontent.com/CrowdStrike/cloud-resource-estimator/main
 export AWS_THREADS=4
 export AWS_BATCH_SIZE=15
 export AWS_BATCH_DELAY=30
-curl https://raw.githubusercontent.com/CrowdStrike/cloud-resource-estimator/main/benchmark.sh | bash
+RELEASE_VERSION="v1.0.0"
+curl -sLO "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/benchmark.sh"
+curl -sL "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/checksum.txt" \
+  | grep benchmark.sh | sha256sum -c        # Linux / CloudShell
+  # | grep benchmark.sh | shasum -a 256 -c  # macOS
+chmod +x benchmark.sh && ./benchmark.sh aws
 ```
 
 #### Large Organizations (200+ accounts)
@@ -100,7 +170,12 @@ export AWS_THREADS=2
 export AWS_BATCH_SIZE=10
 export AWS_BATCH_DELAY=60
 export AWS_API_DELAY=0.2
-curl https://raw.githubusercontent.com/CrowdStrike/cloud-resource-estimator/main/benchmark.sh | bash
+RELEASE_VERSION="v1.0.0"
+curl -sLO "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/benchmark.sh"
+curl -sL "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/checksum.txt" \
+  | grep benchmark.sh | sha256sum -c        # Linux / CloudShell
+  # | grep benchmark.sh | shasum -a 256 -c  # macOS
+chmod +x benchmark.sh && ./benchmark.sh aws
 ```
 
 ### Resume Interrupted Runs
@@ -109,7 +184,12 @@ If the script times out or is interrupted, it automatically saves progress and c
 
 ```shell
 # The script will automatically resume from where it left off
-curl https://raw.githubusercontent.com/CrowdStrike/cloud-resource-estimator/main/benchmark.sh | bash
+RELEASE_VERSION="v1.0.0"
+curl -sLO "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/benchmark.sh"
+curl -sL "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/checksum.txt" \
+  | grep benchmark.sh | sha256sum -c        # Linux / CloudShell
+  # | grep benchmark.sh | shasum -a 256 -c  # macOS
+chmod +x benchmark.sh && ./benchmark.sh aws
 ```
 
 The script will display progress and automatically skip completed accounts.

--- a/Azure/README.md
+++ b/Azure/README.md
@@ -13,7 +13,12 @@ No changes will be made to your account. No data will be sent anywhere and will 
 ### Run the script
 
 ```shell
-curl https://raw.githubusercontent.com/CrowdStrike/cloud-resource-estimator/main/benchmark.sh | bash
+RELEASE_VERSION="v1.0.0"
+curl -sLO "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/benchmark.sh"
+curl -sL "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/checksum.txt" \
+  | grep benchmark.sh | sha256sum -c        # Linux / CloudShell
+  # | grep benchmark.sh | shasum -a 256 -c  # macOS
+chmod +x benchmark.sh && ./benchmark.sh azure
 ```
 
 ### Collect the findings

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 
 This multi-cloud resource auditing utility helps organizations calculate the size of their cloud deployments across AWS, Azure, and Google Cloud Platform. It's designed for **CrowdStrike CWP/Horizon licensing calculations** and cloud security posture management (CSPM) benchmarking.
 
+## Security
+
+- All output (CSV, progress file) is written locally — nothing is sent to CrowdStrike or any external service automatically.
+- **Least-privilege recommendation:** This script requires read-only permissions only. Do not run it with root account credentials or `AdministratorAccess`. Use a dedicated IAM role scoped to the actions the script needs (`ec2:Describe*`, `ecs:List*`/`Describe*`, `eks:List*`/`Describe*`, `organizations:ListAccounts`).
+- Each release ships a `checksum.txt`. Verify the download before running (see installation steps below).
+
 ## What This Tool Does
 
 The Cloud Resource Estimator performs **read-only** scanning of your cloud infrastructure to count:
@@ -110,10 +116,14 @@ For those who prefer to run the script locally, or would like to run the script 
 
 #### Steps
 
-1. Download the script:
+1. Download the script and verify its checksum:
 
     ```shell
-    curl -O https://raw.githubusercontent.com/CrowdStrike/cloud-resource-estimator/main/benchmark.sh
+    RELEASE_VERSION="v1.0.0"
+    curl -sLO "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/benchmark.sh"
+    curl -sL "https://github.com/CrowdStrike/cloud-resource-estimator/releases/download/${RELEASE_VERSION}/checksum.txt" \
+      | grep benchmark.sh | sha256sum -c        # Linux / CloudShell
+      # | grep benchmark.sh | shasum -a 256 -c  # macOS
     ```
 
 1. Set execution permissions:
@@ -129,20 +139,6 @@ For those who prefer to run the script locally, or would like to run the script 
     ```
 
 ---
-
-**Alternatively, you can run the script directly from the URL:**
-
-- Run the script against AWS and Azure:
-
-    ```shell
-    curl https://raw.githubusercontent.com/CrowdStrike/cloud-resource-estimator/main/benchmark.sh | bash -s -- aws azure
-    ```
-
-- Run the script and let it determine the available cloud providers:
-
-    ```shell
-    curl https://raw.githubusercontent.com/CrowdStrike/cloud-resource-estimator/main/benchmark.sh | bash
-    ```
 
 ## Development
 

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -3,7 +3,8 @@
 # Based on the cloud provider, downloads the necessary scripts
 # to perform a sizing calculation.
 
-base_url=https://raw.githubusercontent.com/CrowdStrike/Cloud-Benchmark/main
+RELEASE_VERSION="v1.0.0"
+base_url="https://raw.githubusercontent.com/CrowdStrike/cloud-resource-estimator/${RELEASE_VERSION}"
 
 # Usage message
 usage() {


### PR DESCRIPTION
- Remove all curl | bash patterns from README.md, AWS/README.md, and Azure/README.md — replaced with a download-verify-run pattern using versioned release URLs
- Add checksum verification to install steps using `sha256sum -c` (Linux/CloudShell) and `shasum -a 256 -c` (macOS)
- Add .github/workflows/release.yml — on release creation, generates checksum.txt (SHA256 of benchmark.sh and all three cloud benchmark scripts) and uploads all artifacts to the GitHub Release
- Fix benchmark.sh `base_url` — was pointing at the wrong repo (CrowdStrike/Cloud-Benchmark/main); now points at this repo with a pinned RELEASE_VERSION variable
- Add Security section to README.md covering read-only/local-only output and least-privilege IAM guidance
- Add Least-Privilege IAM Policy section to AWS/README.md with two minimal JSON policies — one for the management/payer account identity (`sts:AssumeRole`, `organizations:ListAccounts`) and one for the member account role (9 read-only EC2/EKS/ECS actions)