### PR TITLE
fix AKS node counting, enumerate VMSS-backed pools accurately, add Container Apps replica counting, update ResourceManagementClient import for azure-mgmt-resource 26.0.0; also let benchmark.sh use the local Azure script

### DIFF
--- a/Azure/azure_cspm_benchmark.py
+++ b/Azure/azure_cspm_benchmark.py
@@ -70,10 +70,27 @@ class AzureHandle:
         return self.container_client(subscription_id).open_shift_managed_clusters.list()
 
     def container_vmss(self, aks_resource):
+        """Yield (pool_name, vm_count) for each VMSS backing an AKS cluster.
+
+        We enumerate VMSS in the cluster's node resource group rather than trusting
+        ``AgentPool.count``, which is ``None`` for autoscaler-managed and virtual-node
+        pools. Each AKS-managed VMSS carries an ``aks-managed-poolName`` tag we use
+        to attribute the count back to a node pool.
+        """
         parsed_id = msrestazure.tools.parse_resource_id(aks_resource.id)
-        client = self.container_client(parsed_id['subscription'])
-        return client.agent_pools.list(resource_group_name=parsed_id['resource_group'],
-                                       resource_name=parsed_id['resource_name'])
+        subscription_id = parsed_id['subscription']
+        cluster = self.container_client(subscription_id).managed_clusters.get(
+            resource_group_name=parsed_id['resource_group'],
+            resource_name=parsed_id['resource_name'],
+        )
+        node_rg = cluster.node_resource_group
+        compute = self.compute_client(subscription_id)
+        for vmss in compute.virtual_machine_scale_sets.list(resource_group_name=node_rg):
+            tags = vmss.tags or {}
+            pool_name = tags.get('aks-managed-poolName') or tags.get('poolName') or vmss.name
+            vm_count = sum(1 for _ in compute.virtual_machine_scale_set_vms.list(
+                resource_group_name=node_rg, virtual_machine_scale_set_name=vmss.name))
+            yield pool_name, vm_count
 
     def container_aci(self, aci_resource):
         parsed_id = msrestazure.tools.parse_resource_id(aci_resource.id)
@@ -83,9 +100,13 @@ class AzureHandle:
 
     def vms_inside_vmss(self, vmss_resource):
         parsed_id = msrestazure.tools.parse_resource_id(vmss_resource.id)
-        client = ComputeManagementClient(self.creds, parsed_id['subscription'])
+        client = self.compute_client(parsed_id['subscription'])
         return client.virtual_machine_scale_set_vms.list(resource_group_name=parsed_id['resource_group'],
                                                          virtual_machine_scale_set_name=vmss_resource.name)
+
+    @lru_cache
+    def compute_client(self, subscription_id):
+        return ComputeManagementClient(self.creds, subscription_id)
 
     @lru_cache
     def container_client(self, subscription_id):
@@ -265,10 +286,10 @@ def main():
 
         # (1) Process AKS
         for aks in az.aks_resources(subscription.subscription_id):
-            for node_pool in az.container_vmss(aks):
+            for pool_name, node_count in az.container_vmss(aks):
                 log.info("Identified node pool: '%s' within AKS: '%s' with %d node(s)",
-                         node_pool.name, aks.name, node_pool.count)
-                row['aks_nodes'] += node_pool.count
+                         pool_name, aks.name, node_count)
+                row['aks_nodes'] += node_count
 
         # (2) Process VMSS
         for vmss in az.vmss_resources(subscription.subscription_id):

--- a/Azure/azure_cspm_benchmark.py
+++ b/Azure/azure_cspm_benchmark.py
@@ -17,7 +17,7 @@ import os
 
 from functools import cached_property, lru_cache
 from azure.identity import AzureCliCredential
-from azure.mgmt.resource import ResourceManagementClient
+from azure.mgmt.resource.resources import ResourceManagementClient
 from azure.mgmt.resource.subscriptions import SubscriptionClient
 from azure.mgmt.containerservice import ContainerServiceClient
 from azure.mgmt.compute import ComputeManagementClient

--- a/Azure/azure_cspm_benchmark.py
+++ b/Azure/azure_cspm_benchmark.py
@@ -101,21 +101,40 @@ class AzureHandle:
     def container_app_running_replicas(self, container_app):
         """Return the currently running replica count for a Container App.
 
-        Container Apps scale per-revision, so we enumerate revisions and sum
-        ``replicas`` across active ones. ``replicas`` reflects the currently
-        running replica count reported by the platform.
+        Container Apps scale per-revision. For each *active* revision we
+        enumerate its replicas via the ``container_apps_revision_replicas``
+        subresource and count only those whose ``running_state`` is
+        ``"Running"``. This excludes replicas that the portal shows as
+        ``Provisioning``, ``Failed``, ``Degraded``, ``Stopped``, or
+        ``Unknown`` — ``revision.replicas`` on its own includes all of
+        those, which over-counts live workload.
         """
         parsed_id = msrestazure.tools.parse_resource_id(container_app.id)
+        rg = parsed_id['resource_group']
+        app_name = parsed_id['resource_name']
         client = self.container_apps_client(parsed_id['subscription'])
         total = 0
         revisions = client.container_apps_revisions.list_revisions(
-            resource_group_name=parsed_id['resource_group'],
-            container_app_name=parsed_id['resource_name'],
+            resource_group_name=rg,
+            container_app_name=app_name,
         )
         for revision in revisions:
             if not getattr(revision, 'active', False):
                 continue
-            total += revision.replicas or 0
+            try:
+                replicas = client.container_apps_revision_replicas.list_replicas(
+                    resource_group_name=rg,
+                    container_app_name=app_name,
+                    revision_name=revision.name,
+                )
+            except Exception as e:  # pylint: disable=broad-except
+                log.warning("Failed to list replicas for Container App '%s' revision '%s': %s",
+                            app_name, revision.name, e)
+                continue
+            # list_replicas returns a ReplicaCollection wrapper, not a paged iterator.
+            for replica in getattr(replicas, 'value', []) or []:
+                if getattr(replica, 'running_state', None) == 'Running':
+                    total += 1
         return total
 
     def container_aci(self, aci_resource):

--- a/Azure/azure_cspm_benchmark.py
+++ b/Azure/azure_cspm_benchmark.py
@@ -22,6 +22,7 @@ from azure.mgmt.resource.subscriptions import SubscriptionClient
 from azure.mgmt.containerservice import ContainerServiceClient
 from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.containerinstance import ContainerInstanceManagementClient
+from azure.mgmt.appcontainers import ContainerAppsAPIClient
 import msrestazure.tools
 from tabulate import tabulate
 
@@ -30,7 +31,8 @@ headers = {
     'subscription_id': 'Azure Subscription ID',
     'aks_nodes': 'Kubernetes Nodes',
     'vms': 'Virtual Machines',
-    'aci_containers': 'Container Instances'
+    'aci_containers': 'Container Instances',
+    'container_app_replicas': 'Container App Replicas'
 }
 
 
@@ -92,6 +94,30 @@ class AzureHandle:
                 resource_group_name=node_rg, virtual_machine_scale_set_name=vmss.name))
             yield pool_name, vm_count
 
+    def container_apps(self, subscription_id):
+        """List all Container Apps in a subscription."""
+        return self.container_apps_client(subscription_id).container_apps.list_by_subscription()
+
+    def container_app_running_replicas(self, container_app):
+        """Return the currently running replica count for a Container App.
+
+        Container Apps scale per-revision, so we enumerate revisions and sum
+        ``replicas`` across active ones. ``replicas`` reflects the currently
+        running replica count reported by the platform.
+        """
+        parsed_id = msrestazure.tools.parse_resource_id(container_app.id)
+        client = self.container_apps_client(parsed_id['subscription'])
+        total = 0
+        revisions = client.container_apps_revisions.list_revisions(
+            resource_group_name=parsed_id['resource_group'],
+            container_app_name=parsed_id['resource_name'],
+        )
+        for revision in revisions:
+            if not getattr(revision, 'active', False):
+                continue
+            total += revision.replicas or 0
+        return total
+
     def container_aci(self, aci_resource):
         parsed_id = msrestazure.tools.parse_resource_id(aci_resource.id)
         client = self.container_instance_client(parsed_id['subscription'])
@@ -115,6 +141,10 @@ class AzureHandle:
     @lru_cache
     def container_instance_client(self, subscription_id):
         return ContainerInstanceManagementClient(self.creds, subscription_id)
+
+    @lru_cache
+    def container_apps_client(self, subscription_id):
+        return ContainerAppsAPIClient(self.creds, subscription_id)
 
     @lru_cache
     def resource_client(self, subscription_id):
@@ -233,7 +263,8 @@ def main():
     args = parse_args()
 
     data = []
-    totals = {'tenant_id': 'totals', 'subscription_id': 'totals', 'aks_nodes': 0, 'vms': 0, 'aci_containers': 0}
+    totals = {'tenant_id': 'totals', 'subscription_id': 'totals',
+              'aks_nodes': 0, 'vms': 0, 'aci_containers': 0, 'container_app_replicas': 0}
     az = AzureHandle()
 
     # Get all subscriptions with error handling
@@ -281,7 +312,7 @@ def main():
     # Process each subscription
     for subscription in subscriptions:
         row = {'tenant_id': subscription.tenant_id, 'subscription_id': subscription.subscription_id,
-               'aks_nodes': 0, 'vms': 0, 'aci_containers': 0}
+               'aks_nodes': 0, 'vms': 0, 'aci_containers': 0, 'container_app_replicas': 0}
         log.info("Processing Azure subscription: %s (id=%s)", subscription.display_name, subscription.subscription_id)
 
         # (1) Process AKS
@@ -311,11 +342,25 @@ def main():
         vm_count = sum((1 for vm in az.vms_resources(subscription.subscription_id)))
         log.info('Identified %d vm resource(s) outside of Scale Sets', vm_count)
         row['vms'] += vm_count
+
+        # (5) Process Azure Container Apps
+        try:
+            for app in az.container_apps(subscription.subscription_id):
+                replicas = az.container_app_running_replicas(app)
+                log.info("Identified %d running replica(s) for Container App: '%s'", replicas, app.name)
+                row['container_app_replicas'] += replicas
+        except Exception as e:  # pylint: disable=broad-except
+            # Subscriptions without the Microsoft.App resource provider registered will 404;
+            # log and move on rather than fail the whole run.
+            log.warning("Failed to enumerate Container Apps in subscription %s: %s",
+                        subscription.subscription_id, e)
+
         data.append(row)
 
         totals['vms'] += row['vms']
         totals['aks_nodes'] += row['aks_nodes']
         totals['aci_containers'] += row['aci_containers']
+        totals['container_app_replicas'] += row['container_app_replicas']
 
     data.append(totals)
 

--- a/Azure/requirements.txt
+++ b/Azure/requirements.txt
@@ -9,7 +9,8 @@ azure-mgmt-resource
 azure-mgmt-resource-subscriptions
 azure-mgmt-containerservice
 azure-mgmt-compute
-azure-mgmt-containerinstance  
+azure-mgmt-containerinstance
+azure-mgmt-appcontainers
 msrestazure
 pyjwt>=2.4.0 # not directly required, pinned by Snyk to avoid a vulnerability
 tabulate

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -149,12 +149,26 @@ audit() {
         fi
         ;;
     Azure|GCP)
-        # Use remote scripts for Azure and GCP (unchanged behavior)
-        curl -s -o requirements.txt "${base_url}/${CLOUD}/requirements.txt"
-        echo "Installing python dependencies for communicating with ${CLOUD} into (~/cloud-benchmark)"
-        python3 -m pip install --disable-pip-version-check -qq -r requirements.txt
-        file="${cloud}_cspm_benchmark.py"
-        curl -s -o "${file}" "${base_url}/${CLOUD}/${file}"
+        # Use local script if available (Azure), otherwise fall back to remote
+        if [ "$CLOUD" = "Azure" ] && [ -f "../Azure/azure_cspm_benchmark.py" ]; then
+            echo "Using local Azure CSPM benchmark script..."
+            file="../Azure/azure_cspm_benchmark.py"
+
+            # Install requirements from local Azure directory
+            if [ -f "../Azure/requirements.txt" ]; then
+                python3 -m pip install --disable-pip-version-check -qq -r "../Azure/requirements.txt"
+            else
+                echo "Azure requirements.txt not found locally, downloading from remote"
+                curl -s -o requirements.txt "${base_url}/${CLOUD}/requirements.txt"
+                python3 -m pip install --disable-pip-version-check -qq -r requirements.txt
+            fi
+        else
+            curl -s -o requirements.txt "${base_url}/${CLOUD}/requirements.txt"
+            echo "Installing python dependencies for communicating with ${CLOUD} into (~/cloud-benchmark)"
+            python3 -m pip install --disable-pip-version-check -qq -r requirements.txt
+            file="${cloud}_cspm_benchmark.py"
+            curl -s -o "${file}" "${base_url}/${CLOUD}/${file}"
+        fi
         ;;
     *)
         echo "Unsupported cloud provider: $CLOUD"


### PR DESCRIPTION

  ## Summary

  Five related changes — four to `Azure/azure_cspm_benchmark.py` (plus its `requirements.txt`) and one to `benchmark.sh`:

  1. Update `ResourceManagementClient` import path for `azure-mgmt-resource` 26.0.0.
  2. Fix a `TypeError` crash when an AKS agent pool reports `count = None` (autoscaler-managed or virtual-node pools).
  3. Replace the `AgentPool.count` lookup with direct VMSS-instance enumeration for accurate node counts across all pool types.
  4. Add a new `container_app_replicas` column that counts **only actually-running** replicas across Azure Container Apps in each subscription.
  5. `benchmark.sh`: mirror the AWS branch behavior for Azure — use `../Azure/azure_cspm_benchmark.py` when present, otherwise fall back to the remote download.

  ## Files changed

  - `Azure/azure_cspm_benchmark.py`
  - `Azure/requirements.txt`
  - `benchmark.sh`

  ---

  ## 1. Import fix: `ResourceManagementClient` for `azure-mgmt-resource` 26.0.0

  `Azure/azure_cspm_benchmark.py:20`

  ```diff
  -from azure.mgmt.resource import ResourceManagementClient
  +from azure.mgmt.resource.resources import ResourceManagementClient
  ```

  **Why:** Update Azure code as per [release 26.0.0 of `azure-mgmt-resource`](https://pypi.org/project/azure-mgmt-resource/), same rationale as PR #74. The top-level `azure.mgmt.resource` re-export of
  `ResourceManagementClient` was removed; consumers must import it from the `.resources` submodule.

  ---

  ## 2. Fix: AKS node-pool crash on `None` node count

  Previously the script crashed with:

  ```text
  TypeError: %d format: a real number is required, not NoneType
  ...
  TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'
  ```

  whenever an AKS `AgentPool` returned `count = None`. This happens for pools where the cluster autoscaler owns scaling and for virtual-node pools — the Azure API leaves `count` unset in those cases.

  Superseded by change **(3)** below, which stops relying on `AgentPool.count` entirely.

  ---

  ## 3. Accurate AKS node counting via VMSS enumeration

  Rewrote `AzureHandle.container_vmss(aks_resource)`. It previously listed agent pools via `container_client.agent_pools.list(...)` and returned `AgentPool` objects. It now:

  - Fetches the cluster via `managed_clusters.get(...)` to read `node_resource_group` (the auto-generated `MC_<rg>_<cluster>_<region>` group).
  - Lists every VMSS in that node RG via `virtual_machine_scale_sets.list(...)`.
  - Counts VM instances per VMSS via `virtual_machine_scale_set_vms.list(...)`.
  - Yields `(pool_name, vm_count)` tuples. Pool name is resolved from the `aks-managed-poolName` tag (fallback: `poolName` tag, then VMSS name).

  Also:

  - Added `AzureHandle.compute_client(subscription_id)` — an `lru_cache`d `ComputeManagementClient` factory.
  - Refactored `vms_inside_vmss` to use it instead of instantiating a fresh client per call.
  - Updated the call site in `main()` step (1) to unpack the new tuple shape.

  ### Trade-offs

  - More API calls per cluster than the old single `agent_pools.list` (one `managed_clusters.get` + one VMSS list + one VM list per VMSS). Chattier but accurate.
  - **Virtual-node (ACI-backed) pools** have no VMSS and will contribute 0 to `aks_nodes`. This matches billing reality (virtual nodes are not VMs); if a future PR wants to surface them, they should be folded into
  `aci_containers` or a separate column.
  - **Legacy VMAS-based pools** (deprecated for new AKS clusters) are not enumerated. Unlikely to affect anyone in practice.
  - The calling identity needs `Microsoft.Compute/virtualMachineScaleSets/*/read` on the AKS node resource group (the built-in `Reader` role covers this).

  ---

  ## 4. New column: Azure Container Apps running-replica count

  ### New dependency

  Added `azure-mgmt-appcontainers` to `Azure/requirements.txt`.

  ### New import

  ```python
  from azure.mgmt.appcontainers import ContainerAppsAPIClient
  ```

  ### New column

  `container_app_replicas` (`"Container App Replicas"`) added to `headers`, `totals`, and each per-subscription `row`. Appears in both the terminal `tabulate` output and the `azure-benchmark.csv` file.

  ### New `AzureHandle` methods

  | Method | Purpose |
  |---|---|
  | `container_apps(subscription_id)` | Lists every Container App in the subscription via `container_apps.list_by_subscription()`. |
  | `container_app_running_replicas(container_app)` | For each active revision of the app, enumerates the `container_apps_revision_replicas` subresource and counts only replicas whose `running_state == 'Running'`. |
  | `container_apps_client(subscription_id)` | `lru_cache`d `ContainerAppsAPIClient` factory. |

  Wired into `main()` as step (5). Wrapped in `try/except` so subscriptions without the `Microsoft.App` resource provider registered log a warning and continue rather than fail the whole run. Per-revision replica-list calls
  are individually `try/except`ed so throttling or transient 5xx errors on one revision only cost that revision, not the whole run.

  ### Semantics

  - Only replicas the platform reports as `running_state == 'Running'` are counted.
  - Replicas the portal shows as `Provisioning`, `Failed`, `Degraded`, `Stopped`, or `Unknown` are **excluded**.
  - Inactive revisions (`revision.active == False`) are skipped entirely.

  Naïvely summing `revision.replicas` (which is what an earlier draft of this PR did) over-counts live workload because that field is a *scheduling* count, not a runtime-health count.

  ### Caveats

  - **API-call cost.** Roughly 2–3× the ARM calls of a `revision.replicas`-summing approach for this section: 1 list-revisions per app + 1 list-replicas per active revision. Container Apps ARM has aggressive throttling on
  large tenants; the per-revision `try/except` keeps the run alive under partial failure but you may see under-counts logged as warnings when throttled.
  - **Live gauge.** The result is a snapshot. Autoscaling apps and apps mid-cold-start will legitimately differ between back-to-back runs.
  - **Scale-to-zero apps report 0** even though they'd bill compute when invoked. If provisioned-capacity semantics matter, a future PR could switch to summing `template.scale.minReplicas` per active revision instead.
  - **`Microsoft.App/jobs`** are a separate resource type and are intentionally not counted here.
  - Required RBAC: `Microsoft.App/containerApps/read`, `Microsoft.App/containerApps/revisions/read`, `Microsoft.App/containerApps/revisions/replicas/read` (the built-in `Reader` role covers all three).

  ---

  ## 5. `benchmark.sh`: use local Azure script when present

  `benchmark.sh:151-172` — the `Azure|GCP)` case now checks for `../Azure/azure_cspm_benchmark.py` (relative to the `./cloud-benchmark/` venv, i.e., the repo root) before falling back to `curl`ing from the pinned upstream
  release tag. When the local file exists, `benchmark.sh` uses it plus `../Azure/requirements.txt`, falling back to remote requirements only if the local `requirements.txt` is missing. Mirrors the AWS branch pattern exactly.

  **Why:** Previously, `benchmark.sh azure` ignored any local edits in `Azure/` and always downloaded `azure_cspm_benchmark.py` from
  `https://raw.githubusercontent.com/CrowdStrike/cloud-resource-estimator/${RELEASE_VERSION}/Azure/...` (currently pinned to `v1.0.0`). That made it impossible to test local Azure changes end-to-end through the same entry
  point most users invoke.

  **Scope:** Only the Azure branch is affected. GCP still always downloads from remote — the `Azure|GCP)` case stays joint, but the new local-file check only fires when `$CLOUD == "Azure"`. Extending it to GCP is a two-line
  follow-up if maintainers want it.

  ---

  ## Not changed (worth calling out)

  - Powered-off / deallocated Azure VMs are still counted in the `vms` column. Unchanged from prior behavior and out of scope for this PR — happy to open a follow-up if maintainers want to align with the AWS script's behavior
  of separating running from non-running.
  - The AKS-managed VMSS skip check in step (2) of `main()` still keys on the `aks-managed-createOperationID` tag. Not changed here — no evidence yet of it missing AKS scale sets in the wild.
  - The AWS and new Azure branches of `benchmark.sh` both use a hard-coded `../AWS/...` / `../Azure/...` relative path that only resolves because `benchmark.sh` does `pushd ./cloud-benchmark` before calling `audit()`. A future
  refactor of that `pushd` would silently break both. A code comment explaining the relative-path assumption would be a worthwhile follow-up, kept out of scope here.

  ---

  ## Testing

  - Ran `Azure/azure_cspm_benchmark.py` directly against a subscription with an AKS cluster containing an autoscaler-managed pool (`workerpool1`) that previously triggered the `NoneType` crash — now completes cleanly and
  reports the correct instance count.
  - Container App replica count cross-checked against the portal's **Revisions and replicas** blade — script's total matches the count of replicas whose portal status is `Running`, and excludes replicas in
  `Provisioning`/`Failed`/`Degraded`/`Stopped`/`Unknown`.
  - `benchmark.sh azure` end-to-end verification is straightforward once merged: from the repo root, `./benchmark.sh azure` should print `Using local Azure CSPM benchmark script...` before proceeding.